### PR TITLE
MAINT: Turn off Travis emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ script:
     - tox
 after_success:
     - coveralls
+notifications:
+    email: false


### PR DESCRIPTION
Travis emails are too frequent hence turning them off.