### PR TITLE
DOC: Use intersphinx for SciPy, NumPy funcs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,7 +222,7 @@ html_title = "{} v{} Documentation".format(project, version)
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,8 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.extlinks',
+    'numpydoc',
+    'sphinx.ext.intersphinx',
     # cloud's extensions
     'cloud_sptheme.ext.autodoc_sections',
     'cloud_sptheme.ext.relbar_links',
@@ -177,6 +179,12 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 keep_warnings = True
 issue_tracker_url = "gh:ilayn/harold/"
+
+intersphinx_mapping = {
+        'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+        'scipy': ('https://docs.scipy.org/doc/scipy/reference', None)}
+
+numpydoc_show_class_members = False
 
 # =============================================================================
 # Options for HTML output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import mock
 import cloud_sptheme as csp
+import numpydoc
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/harold/_polynomial_ops.py
+++ b/harold/_polynomial_ops.py
@@ -208,8 +208,8 @@ def haroldgcd(*args):
     gcdpoly : ndarray
         Computed GCD of args.
 
-    Example
-    -------
+    Examples
+    --------
     >>> a = haroldgcd(*map(haroldpoly,([-1,-1,-2,-1j,1j],
                                        [-2,-3,-4,-5],
                                        [-2]*10)))
@@ -401,8 +401,8 @@ def haroldpolymul(*args, trim_zeros=True):
     p : ndarray
         The resulting polynomial coefficients.
 
-    Example
-    -------
+    Examples
+    --------
 
     >>> haroldpolymul([0,2,0],[0,0,0,1,3,3,1],[0,0.5,0.5])
     array([ 1.,  4.,  6.,  4.,  1.,  0.])

--- a/harold/_static_ctrl_design.py
+++ b/harold/_static_ctrl_design.py
@@ -62,7 +62,8 @@ def lqr(G, Q, R=None, S=None, weight_on='state'):
     Notes
     -----
     For the conditions that weight matrices should satisfy, see SciPy
-    documentation over ``solve_continous_are`` and ``solve_discrete_are``.
+    documentation over :func:`scipy.linalg.solve_continuous_are` and
+    :func:`scipy.linalg.solve_discrete_are`
 
     Moreover, for the output weighted case, the returned solution is not
     always guaranteed to be the stabilizing solution.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy>=0.19.1
 tabulate
 matplotlib
 cloud_sptheme
+numpydoc

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ def setup_package():
         extras_require={
             'dev': ['check-manifest'],
             'test': ['coverage'],
-            'docs': ['sphinx>=1.7.4', 'cloud-sptheme>=1.9.4']
+            'docs': ['sphinx>=1.7.4', 'cloud-sptheme>=1.9.4', 'numpydoc']
         },
         version=get_version_info()[0]
     )


### PR DESCRIPTION
For a quicker access to referred NumPy, SciPy functions, this PR adds `intersphinx` extension.