### PR TITLE
raise ValueError instead of IndexError

### DIFF
--- a/harold/_classes.py
+++ b/harold/_classes.py
@@ -679,7 +679,7 @@ class Transfer:
             else:
                 # Both MIMO
                 if not self._shape == other.shape:
-                    raise IndexError('Cannot multiply Transfer with {0} '
+                    raise ValueError('Cannot multiply Transfer with {0} '
                                      ' shape with {1} with {2} shape.'
                                      ''.format(self._shape,
                                                type(other).__qualname__,


### PR DESCRIPTION
I was going through the codebase (to take some ideas) and I think a `ValueError` would be more appropriate here.