### PR TITLE
Interchange outputs with inputs in docstring

### DIFF
--- a/harold/_classes.py
+++ b/harold/_classes.py
@@ -128,7 +128,7 @@ class Transfer:
     def shape(self):
         """
         A read only property that holds the shape of the system as a tuple
-        such that the result is ``(# of inputs , # of outputs)``.
+        such that the result is ``(# of outputs, # of inputs)``.
         """
         return self._shape
 


### PR DESCRIPTION
`self._shape` is equal to `(self._outputs, self._inputs)`.