### PR TITLE
ENH: Supply a list of systems for time domain plotting

### DIFF
--- a/harold/_time_domain.py
+++ b/harold/_time_domain.py
@@ -1,26 +1,3 @@
-"""
-The MIT License (MIT)
-
-Copyright (c) 2018 Ilhan Polat
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-"""
 import numpy as np
 from numpy import (reciprocal, einsum, maximum, minimum, zeros_like,
                    atleast_1d, squeeze)

--- a/harold/_time_domain_plots.py
+++ b/harold/_time_domain_plots.py
@@ -33,15 +33,11 @@ def _check_sys_args(sys):
     return syslist
 
 
-def _get_common_dt_tf():
-    pass
-
-
 def step_response_plot(sys, t=None, style=None, **kwargs):
     """
-    Plots the step response of a model. If the system is MIMO then the
+    Plots the step response of model(s). If the model is MIMO then the
     response is plotted as a subplot from input m to output p on a (p x m)
-    plot matrix.
+    plot matrix for each model.
 
     Parameters
     ----------
@@ -127,7 +123,7 @@ def step_response_plot(sys, t=None, style=None, **kwargs):
     return axs
 
 
-def impulse_response_plot(sys, t=None):
+def impulse_response_plot(sys, t=None, style=None, **kwargs):
     """
     Plots the impulse response of a model. If the system is MIMO then the
     response is plotted as a subplot from input m to output p on a (p x m)
@@ -136,9 +132,18 @@ def impulse_response_plot(sys, t=None):
     Parameters
     ----------
     sys : {State, Transfer}
-        The system to be simulated
+        The system(s) for which the impulse response plots will be drawn. For
+        multiple plots, place the systems inside a list, tuples, etc.
+        Generators will not work as they will be exhausted before the plotting
+        is performed.
     t : array_like, optional
-        The 1D array that represents the time sequence
+        The 1D array that represents the time sequence. If sys is an iterable
+        t is used for all systems.
+    style : cycler.Cycler, optional
+        Matplotlib cycler class instance for defining the properties of the
+        plot artists. If not given, the current defaults will be used.
+
+    If any, all remaining kwargs are passed to `matplotlib.pyplot.subplots()`.
 
     Returns
     -------
@@ -146,32 +151,60 @@ def impulse_response_plot(sys, t=None):
         Returns the figure handle of the impulse response
 
     """
-    _check_for_state_or_transfer(sys)
-    yout, tout = simulate_impulse_response(sys, t=t)
+    syslist = _check_sys_args(sys)
+    # Prepare the axes for the largest model
+    max_p, max_m = np.max(np.array([x.shape for x in syslist]), axis=0)
 
-    if sys._isSISO:
-        fig, axs = plt.subplots(1, 1, squeeze=False)
-        if sys._isdiscrete:
-            axs[0, 0].step(tout, yout, where='post')
-        else:
-            axs[0, 0].plot(tout, yout)
-
-        axs[0, 0].grid(b=True)
+    # Put some more space between columns to avoid ticklabel placement clashes
+    gridspec_kw = kwargs.pop('gridspec_kw', None)
+    if gridspec_kw is None:
+        gridspec_kw = {'wspace': 0.5}
     else:
-        nrows, ncols = (yout.shape[1], 1) if yout.ndim == 2 else yout.shape[1:]
-        fig, axs = plt.subplots(nrows=nrows, ncols=ncols, sharex=True,
-                                sharey=True, squeeze=False)
+        wspace = gridspec_kw.get('wspace', 0.5)
+        gridspec_kw['wspace'] = wspace
 
-        # Get the appropriate plotter line plot or a step plot
-        ptype = 'step' if sys._isdiscrete else 'plot'
-        w_dict = {'where': 'post'} if sys._isdiscrete else {}
-        for row in range(nrows):
-            for col in range(ncols):
-                getattr(axs[row, col], ptype)(tout, yout[:, row, col]
-                                              if yout.ndim == 3
-                                              else yout[:, row], **w_dict)
-                axs[row, col].grid(b=True)
+    # MIMO plots needs a bit bigger figure, offer a saner default
+    figsize = kwargs.pop('figsize', None)
+    if figsize is None:
+        figsize = (6.0 + 1.2*(max_m - 1), 4 + 1.5*(max_p - 1))
 
+    if style is None:
+        style = mpl.cycler(mpl.rcParams['axes.prop_cycle'])
+
+    # Create fig and axes
+    fig, axs = plt.subplots(max_p, max_m, sharex=True, squeeze=False,
+                            gridspec_kw=gridspec_kw,
+                            figsize=figsize,
+                            **kwargs)
+
+    # TODO: If multiple systems are given and no t given we need to find a
+    # compromise for the shorter ones. For now, just plot everything on top of
+    # each other independently and cut to the shortest. Yes, it sucks; I know.
+    tmin = np.inf
+    for sys in syslist:
+        yout, tout = simulate_impulse_response(sys, t=t)
+        tmin = np.min([tout[-1], tmin])
+        if sys._isSISO:
+            if sys._isdiscrete:
+                axs[0, 0].step(tout, yout, where='post')
+            else:
+                axs[0, 0].plot(tout, yout)
+
+            axs[0, 0].grid(b=True)
+        else:
+            nrows, ncols = (yout.shape[1], 1) if yout.ndim == 2 else\
+                yout.shape[1:]
+
+            # Get the appropriate plotter line plot or a step plot
+            ptype = 'step' if sys._isdiscrete else 'plot'
+            w_dict = {'where': 'post'} if sys._isdiscrete else {}
+            for row in range(nrows):
+                for col in range(ncols):
+                    getattr(axs[row, col], ptype)(tout, yout[:, row, col]
+                                                  if yout.ndim == 3
+                                                  else yout[:, row], **w_dict)
+                    axs[row, col].grid(b=True)
+    axs[0, 0].set_xlim(left=0, right=tmin)
     fig.text(0, .5, 'Amplitude', ha='center', va='center', rotation='vertical')
     fig.text(.5, 0, 'Time', ha='center', va='center')
     fig.suptitle('Impulse response')

--- a/harold/_time_domain_plots.py
+++ b/harold/_time_domain_plots.py
@@ -82,7 +82,9 @@ def step_response_plot(sys, t=None, style=None, **kwargs):
         style = mpl.cycler(mpl.rcParams['axes.prop_cycle'])
 
     # Create fig and axes
-    fig, axs = plt.subplots(max_p, max_m, sharex=True, squeeze=False,
+    fig, axs = plt.subplots(max_p, max_m,
+                            sharex=True, sharey=True,
+                            squeeze=False,
                             gridspec_kw=gridspec_kw,
                             figsize=figsize,
                             **kwargs)
@@ -91,14 +93,14 @@ def step_response_plot(sys, t=None, style=None, **kwargs):
     # compromise for the shorter ones. For now, just plot everything on top of
     # each other independently and cut to the shortest. Yes, it sucks; I know.
     tmin = np.inf
-    for sys in syslist:
+    for sys, sty in zip(syslist, style):
         yout, tout = simulate_step_response(sys, t=t)
         tmin = np.min([tout[-1], tmin])
         if sys._isSISO:
             if sys._isdiscrete:
-                axs[0, 0].step(tout, yout, where='post')
+                axs[0, 0].step(tout, yout, where='post', **sty)
             else:
-                axs[0, 0].plot(tout, yout)
+                axs[0, 0].plot(tout, yout, **sty)
 
             axs[0, 0].grid(b=True)
         else:
@@ -112,7 +114,9 @@ def step_response_plot(sys, t=None, style=None, **kwargs):
                 for col in range(ncols):
                     getattr(axs[row, col], ptype)(tout, yout[:, row, col]
                                                   if yout.ndim == 3
-                                                  else yout[:, row], **w_dict)
+                                                  else yout[:, row],
+                                                  **w_dict,
+                                                  **sty)
                     axs[row, col].grid(b=True)
 
     axs[0, 0].set_xlim(left=0, right=tmin)
@@ -172,7 +176,8 @@ def impulse_response_plot(sys, t=None, style=None, **kwargs):
         style = mpl.cycler(mpl.rcParams['axes.prop_cycle'])
 
     # Create fig and axes
-    fig, axs = plt.subplots(max_p, max_m, sharex=True, squeeze=False,
+    fig, axs = plt.subplots(max_p, max_m, sharex=True, sharey=True,
+                            squeeze=False,
                             gridspec_kw=gridspec_kw,
                             figsize=figsize,
                             **kwargs)


### PR DESCRIPTION
This is slightly more convenient for plotting all systems at once. Still cuts to the shortest response if no time array is given to avoid excessive sampling. I don't remember what matlab or octave was doing. I also don't know what to do with legends and leave it to user via kwargs. So 

```python
G = random_state_model(6, 3, 2)
F = random_state_model(6, 2, 3)
H = Transfer(100, [1, 100, 100])
J = discretize(G, 0.1)
step_response_plot([F, G, H, J])
```
gives 

![image](https://user-images.githubusercontent.com/1303842/97933352-d01d7200-1d72-11eb-8877-c7b7801a1ddf.png)


impulse response is also similar. 

Note: tox stuff is still broken, add root-locus and that makes v1.0.2 (finally!).