### PR TITLE
MAINT: Add dcgain method to State and Transfer

### DIFF
--- a/harold/_classes.py
+++ b/harold/_classes.py
@@ -5,6 +5,7 @@ from numpy.random import rand, choice
 from scipy.linalg import (eigvals, svdvals, block_diag, qz, norm, solve, expm,
                           inv, LinAlgError)
 from scipy.linalg._decomp import _asarray_validated
+from scipy.signal import deconvolve
 from scipy.stats import ortho_group
 from tabulate import tabulate
 from itertools import zip_longest, chain
@@ -14,6 +15,7 @@ from ._polynomial_ops import (haroldpoly, haroldpolyadd, haroldpolydiv,
 from ._array_validators import _assert_square
 from ._aux_linalg import haroldsvd
 from ._global_constants import _KnownDiscretizationMethods
+from ._frequency_domain import frequency_response
 from copy import deepcopy
 
 __all__ = ['Transfer', 'State', 'state_to_transfer', 'transfer_to_state',
@@ -139,6 +141,65 @@ class Transfer:
         denominator as the outputs.
         """
         return self._num, self._den
+
+    @property
+    def dcgain(self):
+        """
+        Returns the low-frequency gain of the Transfer model.
+        """
+        if self._isgain:
+            return self.to_array()
+        # Get the common integrator modes out to avoid 0/0 cases:
+        # G = Transfer([1, 0], [1,2,0]) gives NaN otherwise
+
+        dcg = np.zeros([*self.shape], dtype=float)
+        if self._dt is None:
+            for c in range(self._m):
+                for r in range(self._p):
+                    if self._isSISO:
+                        num = self.num.flatten()
+                        den = self.den.flatten()
+                    else:
+                        num = self.num[r][c].flatten()
+                        den = self.den[r][c].flatten()
+
+                    for el in range(len(num)):
+                        if (num[-1] == 0.) and (den[-1] == 0.):
+                            num = num[:-1]
+                            den = den[:-1]
+                        else:
+                            break
+                    else:
+                        dcg[r, c] = 0.
+                        continue
+                    with np.errstate(divide='ignore'):
+                        dcg[r, c] = np.polyval(num, 0) / np.polyval(den, 0)
+
+        else:
+            # Now we need to strip off the discrete -1 poles like above :(
+            # Lack of convenience for 0, evaluate at 1 and see if it is both 0
+            for c in range(self._m):
+                for r in range(self._p):
+                    if self._isSISO:
+                        num = self.num.flatten()
+                        den = self.den.flatten()
+                    else:
+                        num = self.num[r][c].flatten()
+                        den = self.den[r][c].flatten()
+                    for el in range(len(num)):
+                        if (num.sum() == 0) and (den.sum() == 0):
+                            print('hergsdfg')
+                            num, _ = deconvolve(num, [1, -1])
+                            den, _ = deconvolve(den, [1, -1])
+                        else:
+                            break
+                    else:
+                        dcg[r, c] = 0.
+                        continue
+                    print(num, den)
+                    with np.errstate(divide='ignore'):
+                        dcg[r, c] = (np.polyval(num, 1.) / np.polyval(den, 1.))
+        return dcg[0, 0] if self._isSISO else dcg
 
     @property
     def DiscretizedWith(self):

--- a/harold/_frequency_domain.py
+++ b/harold/_frequency_domain.py
@@ -57,14 +57,14 @@ def frequency_response(G, w=None, samples=None, w_unit='Hz', output_unit='Hz',
     if G._isgain:
         if G._isSISO:
             if isinstance(G, Transfer):
-                fr_arr = array([1]*2)*G.num[0, 0]
+                fr_arr = array([1]*len(w))*G.num[0, 0]
             else:
-                fr_arr = array([1]*2)*G.d[0, 0]
+                fr_arr = array([1]*len(w))*G.d[0, 0]
         else:
             if isinstance(G, Transfer):
-                fr_arr = zeros((2,)+G.shape) + G.to_array()
+                fr_arr = zeros((len(w),)+G.shape) + G.to_array()
             else:
-                fr_arr = zeros((2,)+G.shape) + G.d
+                fr_arr = zeros((len(w),)+G.shape) + G.d
 
             fr_arr = rollaxis(fr_arr, 0, 3)
     else:


### PR DESCRIPTION
Not extremely robust evaluation of low frequency value of dynamical models. 

Main issue is the integrator/adder cancellations such as `Transfer([1, 0], [1, 1, 0])` but direct evaluation at `s=0`  would give `0/0`though having a finite DC gain.

Closes #81 